### PR TITLE
Fix Azure Static Web Apps deployment for static site

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -1,0 +1,27 @@
+name: Azure Static Web Apps CI/CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_deploy_job:
+    runs-on: ubuntu-latest
+    name: Build and Deploy Job
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: false
+      
+      - name: Build And Deploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "/" # App source code path
+          api_location: "" # Api source code path - optional
+          output_location: "" # Built app content directory - optional
+          skip_app_build: true # Skip build for static sites


### PR DESCRIPTION
## Summary
- Added `skip_app_build: true` to the Azure Static Web Apps workflow
- Fixes deployment failure caused by missing build script

## Problem
The deployment was failing with:
```
Error: Could not find either 'build' or 'build:azure' node under 'scripts' in package.json
```

## Solution
This is a static AEM Franklin/Edge Delivery Services site that doesn't require a build step. The `skip_app_build` parameter tells Azure Static Web Apps to deploy the files directly without running a build process.

## Test plan
- [ ] Verify workflow syntax is correct
- [ ] Confirm deployment succeeds after merge
- [ ] Check that the site is accessible at the Azure Static Web Apps URL

🤖 Generated with [Claude Code](https://claude.ai/code)