### PR TITLE
feat: Auto-commit incidents index after update

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -4,16 +4,25 @@ on:
   push:
     branches:
       - main
+    # Prevent workflow from running on automated commits to avoid infinite loops
+    paths-ignore:
+      - 'incidents/index.json'
 
 jobs:
   build_and_deploy_job:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    # Add write permissions for contents to allow committing
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
           lfs: false
+          # Use a PAT or GitHub App token to allow the commit to trigger other workflows if needed
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -26,6 +35,26 @@ jobs:
       
       - name: Update incidents index
         run: npm run update-incidents
+      
+      - name: Check for changes in index.json
+        id: check_changes
+        run: |
+          if git diff --quiet incidents/index.json; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No changes detected in incidents/index.json"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Changes detected in incidents/index.json"
+          fi
+      
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add incidents/index.json
+          git commit -m "chore: update incidents index [skip ci]"
+          git push origin main
       
       - name: Build And Deploy
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
## Summary
- Automated the commit and push of `incidents/index.json` after the update-incidents script runs
- Added proper permissions and safeguards to prevent infinite loops

## Changes
- Modified `.github/workflows/azure-static-web-apps.yml` to:
  - Add `contents: write` permission for GitHub Actions
  - Add step to check for changes in `incidents/index.json`
  - Add step to commit and push changes if detected
  - Add `paths-ignore` to prevent workflow from triggering on its own commits
  - Use `[skip ci]` in commit message as additional safeguard

## Safety Measures
The following safeguards prevent infinite loops:
1. **paths-ignore**: Workflow ignores changes to `incidents/index.json`
2. **[skip ci]** in commit message: Additional prevention for CI triggering
3. **Change detection**: Only commits if there are actual changes

## Test plan
- [ ] Verify workflow runs successfully on push to main
- [ ] Confirm index.json is committed when changes are detected
- [ ] Ensure no infinite loop occurs
- [ ] Check that Azure Static Web Apps deployment still works

🤖 Generated with [Claude Code](https://claude.ai/code)