### PR TITLE
chore: merge incident classification updates

### DIFF
--- a/incidents/index.json
+++ b/incidents/index.json
@@ -35,7 +35,9 @@
     "impact": "minor",
     "timestamp": "2025-04-10T10:27:00.000Z",
     "affectedComponents": [
-      "publishing",
+      "publishing"
+    ],
+    "internalServices": [
       "admin-api"
     ],
     "externalVendors": null,
@@ -51,6 +53,7 @@
       "delivery",
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": [
       "cloudflare"
     ],
@@ -62,7 +65,8 @@
     "message": "Executive Summary\n\nOn March 15, 2025, between 7:00 AM and 11:21 AM UTC, approximately 90% of customers experienced issues with the delivery of RUM (Real User Monitoring) scripts due to availability problems with the unpkg.com backend. The incident was caused by unpkg.com experiencing degraded performance, combined with our system's inability to properly handle first-byte timeout errors in the backend fallback mechanism. The issue was identified and resolved by adjusting timeout configurations an",
     "impact": "none",
     "timestamp": "2025-03-18T12:07:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "rum"
     ],
     "externalVendors": [
@@ -79,6 +83,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "aws"
     ],
@@ -93,6 +98,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": [
       "cloudflare"
     ],
@@ -107,6 +113,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "cloudflare"
     ],
@@ -121,6 +128,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "network-issue"
   },
@@ -130,7 +138,8 @@
     "message": "An aemsites organisation owner updated the AEM Code Sync config and accidentally removed all repositories from the config. Github UI is not fully intuitive.\n\nAs a follow up step, a reminder email has been sent to all the owners.",
     "impact": "minor",
     "timestamp": "2024-12-13T09:05:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "code-sync"
     ],
     "externalVendors": [
@@ -147,6 +156,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "zscaler"
     ],
@@ -159,7 +169,9 @@
     "impact": "none",
     "timestamp": "2024-11-11T14:50:00.000Z",
     "affectedComponents": [
-      "publishing",
+      "publishing"
+    ],
+    "internalServices": [
       "sidekick",
       "admin-api"
     ],
@@ -172,7 +184,8 @@
     "message": "Beginning July 30, 2024, at 16:42 UTC, we observed a reduction in available logs for some services. Our services continue to run as expected, with no operational impact. The issue is due to increased error rates and delays affecting AWS services.\n\nBy July 31, 2024 at 4:55 UTC, the increased error rates and delays impacting AWS services had been resolved.",
     "impact": "none",
     "timestamp": "2024-09-11T14:21:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "logging"
     ],
     "externalVendors": [
@@ -186,7 +199,8 @@
     "message": "On 11.09.2024 12:30 UTC we noticed that the AEM Code Sync Github application has stopped dispatching github events since 05:00 UTC. As a result, github actions that are triggered on a repository_dispatch event were not longer invoked. \n\nThe reason was a removed content-write permission of the AEM Code Sync Github application which is required to dispatch events. After restoring the permission, the notifications were dispatched again. \n\nCustomers that use repository_dispatch events in their githu",
     "impact": "minor",
     "timestamp": "2024-09-11T14:08:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "code-sync"
     ],
     "externalVendors": [
@@ -203,6 +217,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "cloudflare"
     ],
@@ -217,6 +232,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "deployment-issue"
   },
@@ -229,6 +245,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "cloudflare"
     ],
@@ -240,7 +257,8 @@
     "message": "On March 18 the system experienced a unexpected indexing load that overwhelmed the indexing queue. Due to a suboptimal configuration the system was not able to process the queue fast enough and clogged indexing processing for all customers.\n\nConsequently, index updates might have been delayed by over 1 hour.\n\nAfter identifying the problem we could reconfigure the queue to avoid similar problems in the future.",
     "impact": "minor",
     "timestamp": "2024-05-27T14:58:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "indexing"
     ],
     "externalVendors": null,
@@ -265,6 +283,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "resource-limits"
   },
@@ -277,6 +296,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "deployment-issue"
   },
@@ -287,7 +307,9 @@
     "impact": "none",
     "timestamp": "2024-04-26T09:00:00.000Z",
     "affectedComponents": [
-      "publishing",
+      "publishing"
+    ],
+    "internalServices": [
       "forms"
     ],
     "externalVendors": [
@@ -301,7 +323,8 @@
     "message": "Between 7:00 am and 12:45 pm (UTC) today, the JavaScript delivery feature of the Helix RUM Collector Service experienced an outage that resulted in slow responses and responses with status code 520 for following request types:\n\n\nhelix-rum-js: this slowed down page rendering for customers of Adobe Experience Manager as a Cloud Service that are part of the VIP program for RUM collection in AEM CS. This affected a small double digit number of customers.\nhelix-rum-enhancer: all customers of AEM CS a",
     "impact": "minor",
     "timestamp": "2024-04-12T14:31:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "rum"
     ],
     "externalVendors": [
@@ -318,6 +341,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "resource-limits"
   },
@@ -327,7 +351,8 @@
     "message": "What happened?\n\nA disruption in the forms service, starting at 15:16 UTC on Thursday, February 1, caused a temporary delay in form submissions. During the incident no data loss occurred. All delayed and pending form submissions were successfully processed by 19:33 UTC on Thursday, February 1.",
     "impact": "none",
     "timestamp": "2024-02-02T21:31:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "forms"
     ],
     "externalVendors": null,
@@ -342,6 +367,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "third-party-outage"
   },
@@ -354,6 +380,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "cloudflare"
     ],
@@ -368,6 +395,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "cloudflare"
     ],
@@ -379,7 +407,8 @@
     "message": "We discovered that the errors were caused by an issue with a specific IO region in Fastly. The impact of the incident lasted for approximately 22 minutes, from 11:42 to 12:04 UTC. During that period we saw an increase of the media delivery error rate from 0% to 4.8%. About 50% of the errored requests were initiated by Bots. Customer impact has been negligible. We will continue to closely monitor error rates of the the infrastructure we are using and take action if necessary.",
     "impact": "minor",
     "timestamp": "2023-12-15T15:11:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "media"
     ],
     "externalVendors": [
@@ -396,6 +425,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "cloudflare"
     ],
@@ -410,6 +440,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "unknown"
   },
@@ -419,7 +450,8 @@
     "message": "Between 9:18 UTC and 14:36 UTC on 18-oct-2023 due to a change in the domain of our externally facing documentation website https://www.hlx.live to https://www.aem.live a small portion of www.hlx.com/tools which hosts resources used by sidekick was redirected accidentally.   \n\nOur analysis shows that 0.6% of the traffic to www.hlx.com/tools during that time window was wrongly redirected and was potentially leading to an issue where users were not able to open up the sidekick library under certain",
     "impact": "minor",
     "timestamp": "2023-10-19T14:01:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "sidekick"
     ],
     "externalVendors": null,
@@ -434,6 +466,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "third-party-outage"
   },
@@ -446,6 +479,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "dns-issue"
   },
@@ -458,6 +492,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "dns-issue"
   },
@@ -471,6 +506,7 @@
       "delivery",
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "third-party-outage"
   },
@@ -481,7 +517,9 @@
     "impact": "minor",
     "timestamp": "2023-02-23T11:48:00.000Z",
     "affectedComponents": [
-      "publishing",
+      "publishing"
+    ],
+    "internalServices": [
       "forms"
     ],
     "externalVendors": [
@@ -495,7 +533,8 @@
     "message": "Between 10:01 am an 10:16 am today, a configuration change to a Serverless function caused the GitHub bot to fail to respond to notifications from GitHub. In total 31 requests were affected.\n\nIf you pushed code changes in that time period, they might not have come through. You can remedy this by pushing an additional, empty commit to the same branch.\n\nIn order to prevent similar issues to arise in the future, we will establish a review process for configuration changes to the production services",
     "impact": "minor",
     "timestamp": "2023-02-09T10:28:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "code-sync"
     ],
     "externalVendors": null,
@@ -510,6 +549,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": [
       "microsoft"
     ],
@@ -522,8 +562,10 @@
     "impact": "minor",
     "timestamp": "2023-01-24T20:59:00.000Z",
     "affectedComponents": [
-      "admin-api",
       "publishing"
+    ],
+    "internalServices": [
+      "admin-api"
     ],
     "externalVendors": [
       "cloudflare"
@@ -539,6 +581,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "fastly"
     ],
@@ -550,7 +593,8 @@
     "message": "An new version of the Franklin admin service conflicted with a behavior of the Franklin github bot which lead to a delay of synchronizations of code updates. The issue was not noticed for a few hours as the function that was affected was not heavily used at the time.\nThe issue is fixed in a newly released version of the Franklin github bot, and all affected code synchronization will be synchronized.",
     "impact": "minor",
     "timestamp": "2022-12-22T22:54:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "code-sync"
     ],
     "externalVendors": [
@@ -567,6 +611,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": [
       "microsoft"
     ],
@@ -582,6 +627,7 @@
       "delivery",
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "third-party-outage"
   },
@@ -591,7 +637,8 @@
     "message": "The underlying reason for the increased error rates on media delivery was a partial outage of Fastly’s Image Optimizer:\nhttps://status.fastly.com/incidents/s542qjby04vb\n\nWe have opened an issue with Fastly support, asking for an official statement about how Fastly is going to address this issue and prevent future such outages.",
     "impact": "minor",
     "timestamp": "2022-06-29T15:29:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "media"
     ],
     "externalVendors": [
@@ -605,7 +652,8 @@
     "message": "On June 20th, 2022, Helix Form processing was delayed for about 4 hours. During this timeframe, new form submissions were still accepted, but would not show up in the target spreadsheets. After the issue has been resolved, normal processing resumed and all stalled form submissions were delivered.\n\nThe issue was caused by a manual rotation of a security credential.",
     "impact": "minor",
     "timestamp": "2022-06-20T05:34:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "forms"
     ],
     "externalVendors": [
@@ -620,8 +668,10 @@
     "impact": "minor",
     "timestamp": "2022-06-07T11:18:00.000Z",
     "affectedComponents": [
-      "admin-api",
       "publishing"
+    ],
+    "internalServices": [
+      "admin-api"
     ],
     "externalVendors": null,
     "rootCause": "dns-issue"
@@ -635,6 +685,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "third-party-outage"
   },
@@ -647,6 +698,7 @@
     "affectedComponents": [
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": [
       "microsoft"
     ],
@@ -662,6 +714,7 @@
       "delivery",
       "publishing"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "unknown"
   },
@@ -671,7 +724,8 @@
     "message": "On March 22nd, 2022, Helix Form processing was delayed for about 30 minutes. During this timeframe, new form submissions were still accepted, but would not show up in the target spreadsheets. After the issue has been resolved, normal processing resumed and all stalled form submissions were delivered.\n\nThe issue was caused by an automated rotation of a security credential.\n\nWe have identified an engineering solution to the problem of automated credential rotation that will be rolled out in the ne",
     "impact": "minor",
     "timestamp": "2022-03-23T09:54:00.000Z",
-    "affectedComponents": [
+    "affectedComponents": null,
+    "internalServices": [
       "forms"
     ],
     "externalVendors": [
@@ -688,6 +742,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": null,
     "rootCause": "unknown"
   },
@@ -700,6 +755,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "github"
     ],
@@ -714,6 +770,7 @@
     "affectedComponents": [
       "delivery"
     ],
+    "internalServices": null,
     "externalVendors": [
       "github"
     ],
@@ -726,8 +783,10 @@
     "impact": "major",
     "timestamp": "2019-05-20T13:39:00.000Z",
     "affectedComponents": [
-      "logging",
       "publishing"
+    ],
+    "internalServices": [
+      "logging"
     ],
     "externalVendors": [
       "fastly"

--- a/scripts/reclassify-incidents.js
+++ b/scripts/reclassify-incidents.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+
+// Define which components are business-level vs internal services
+const BUSINESS_COMPONENTS = ['delivery', 'publishing'];
+const INTERNAL_SERVICES = ['admin-api', 'sidekick', 'code-sync', 'forms', 'rum', 'media', 'indexing', 'logging'];
+
+function reclassifyIncidents() {
+  const indexPath = path.join(dirname, '..', 'incidents', 'index.json');
+
+  // Read the incidents
+  const incidents = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+
+  // Reclassify each incident
+  const reclassified = incidents.map(incident => {
+    if (!incident.affectedComponents || incident.affectedComponents.length === 0) {
+      // If there are no affectedComponents, keep as is
+      return incident;
+    }
+
+    const businessComponents = [];
+    const internalServices = [];
+
+    // Split the components
+    incident.affectedComponents.forEach(component => {
+      if (BUSINESS_COMPONENTS.includes(component)) {
+        businessComponents.push(component);
+      } else if (INTERNAL_SERVICES.includes(component)) {
+        internalServices.push(component);
+      } else {
+        // Unknown component - log warning and keep in business components for safety
+        console.warn(`Unknown component "${component}" in incident ${incident.code}`);
+        businessComponents.push(component);
+      }
+    });
+
+    // Create the new structure
+    return {
+      ...incident,
+      affectedComponents: businessComponents.length > 0 ? businessComponents : null,
+      internalServices: internalServices.length > 0 ? internalServices : null,
+      // Keep externalVendors as is
+    };
+  });
+
+  // Write back the reclassified incidents
+  fs.writeFileSync(indexPath, JSON.stringify(reclassified, null, 2) + '\n');
+  console.log(`Successfully reclassified ${incidents.length} incidents`);
+}
+
+// Run if called directly
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    reclassifyIncidents();
+  } catch (error) {
+    console.error('Error reclassifying incidents:', error);
+    process.exit(1);
+  }
+}
+
+export default reclassifyIncidents;

--- a/scripts/update-incidents-index.js
+++ b/scripts/update-incidents-index.js
@@ -201,13 +201,16 @@ function updateIncidentsIndex() {
       // Preserve classification fields from existing incident if they exist
       if (existingIncidentsMap.has(incident.code)) {
         const existingIncident = existingIncidentsMap.get(incident.code);
-        if (existingIncident.affectedComponents) {
+        if (existingIncident.affectedComponents !== undefined) {
           incident.affectedComponents = existingIncident.affectedComponents;
+        }
+        if (existingIncident.internalServices !== undefined) {
+          incident.internalServices = existingIncident.internalServices;
         }
         if (existingIncident.externalVendors !== undefined) {
           incident.externalVendors = existingIncident.externalVendors;
         }
-        if (existingIncident.rootCause) {
+        if (existingIncident.rootCause !== undefined) {
           incident.rootCause = existingIncident.rootCause;
         }
       }


### PR DESCRIPTION
This PR classifies all existing incidents and ensures the update-incidents-index.js script will retain the classification fields.

- Updated `incidents/index.json` with classification fields for all incidents
- Enhanced `scripts/update-incidents-index.js` to preserve classification data (`affectedComponents`, `externalVendors`, `rootCause`) when updating the index

## Related

- Supersedes #47 (original incident classification work)