### PR TITLE
Improve post-mortem review workflow

### DIFF
--- a/.github/workflows/post-mortem.yml
+++ b/.github/workflows/post-mortem.yml
@@ -6,10 +6,48 @@ on:
     paths:
       # Only run when specific paths are modified
       - "incidents/html/*.html"
+      - "incidents/**/*.html"  # Catch misplaced incident files
       # You can add more specific patterns as needed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
+  validate-incident-location:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check for misplaced incident files
+        run: |
+          # Get list of changed files in this PR
+          git fetch origin ${{ github.base_ref }}
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          # Check for incident files outside incidents/html/ (excluding templates)
+          MISPLACED=$(echo "$CHANGED_FILES" | grep -E '^incidents/[^/]+\.html$' | grep -v 'template' || true)
+
+          if [ -n "$MISPLACED" ]; then
+            echo "❌ Error: Incident files must be placed in incidents/html/ directory"
+            echo ""
+            echo "Misplaced files found:"
+            echo "$MISPLACED"
+            echo ""
+            echo "Please move these files to incidents/html/"
+            exit 1
+          fi
+
+          echo "✅ All incident files are in the correct location"
+
   claude-review-paths:
+    needs: validate-incident-location
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,6 +70,20 @@ jobs:
             Please review this incident post-mortem following industry best practices for SaaS services.
 
             Note: The PR branch is already checked out in the current working directory.
+
+            ## Important: Check for Existing Reviews First
+
+            Before providing feedback:
+            1. Use `gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json reviews,comments` to check for existing reviews from @claude[bot]
+            2. If there are previous reviews from @claude[bot]:
+               - Review only the changes made since the last review
+               - Check if previous feedback has been addressed
+               - For addressed feedback: Update or resolve the original comment thread if possible
+               - For unaddressed feedback: Reference the original comment rather than repeating it
+               - Only add NEW comments for NEW issues or issues that have gotten worse
+            3. If this is the first review, proceed with a full comprehensive review
+
+            This approach prevents comment pile-up and maintains a cleaner review thread.
 
             ## Review Criteria:
 


### PR DESCRIPTION
## Summary

This PR improves the post-mortem review workflow to address two key issues identified in PR #67:

1. **Incident files created in wrong location weren't reviewed**
   - PR #64 created `incidents/AEM-yanvkiuy.html` instead of `incidents/html/AEM-yanvkiuy.html`
   - Path filter didn't match, so no Claude review was triggered
   
2. **Multiple redundant reviews piled up on incremental commits**
   - Claude posted 19 separate reviews across 4 commits in PR #67
   - Each review was independent with no context of previous feedback

## Changes

### 1. Add Validation Job

Added a new `validate-incident-location` job that:
- Runs before the Claude review
- Checks for incident HTML files outside `incidents/html/`
- Excludes template files from validation
- Fails the PR with a clear error message if misplaced files are found

This ensures incidents are always created in the correct location where Claude can review them.

### 2. Add Concurrency Control

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

This cancels any in-progress review when a new commit is pushed, preventing review pile-up.

### 3. Enhance Claude Prompt with Context Awareness

Updated the prompt to instruct Claude to:
1. Check for existing reviews from @claude[bot] first
2. Only comment on changes since the last review
3. Reference previous comments rather than repeating them
4. Only add new comments for new issues

This significantly reduces redundant feedback on incremental commits.

## Test Plan

- [x] Validate that the workflow syntax is correct
- [ ] Test with a PR that creates incident in wrong location (should fail)
- [ ] Test with a PR that creates incident in correct location (should pass validation)
- [ ] Test that incremental commits trigger only one review (old one is cancelled)
- [ ] Verify Claude checks for existing reviews before commenting

## Related

- Fixes issues identified in PR #67
- Related to PR #64 (initial incident that wasn't reviewed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)