### PR TITLE
feat: add CORS headers to Azure Static Web App

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "globalHeaders": {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `staticwebapp.config.json` configuration file to enable CORS headers
- Configure global headers for `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Methods: GET, OPTIONS`
- Enable external applications to access the status page data

## Background
This configuration follows the Azure Static Web Apps documentation for setting global HTTP headers. The configuration applies CORS headers to all responses, allowing cross-origin requests from any domain.

Since this is a public status page, using `*` for the allowed origin is appropriate. The allowed methods are restricted to `GET` and `OPTIONS` for read-only access.

## References
- [Azure Static Web Apps Configuration - Global Headers](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration)

## Test plan
- [ ] Verify the configuration file is valid JSON and under 20KB size limit
- [ ] Deploy to Azure and test CORS headers are present in responses
- [ ] Verify external applications can successfully make cross-origin requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)