### PR TITLE
feat: extract SLO calculation into reusable library

### DIFF
--- a/scripts/slo-calculator.js
+++ b/scripts/slo-calculator.js
@@ -1,0 +1,101 @@
+/**
+ * AEM Service Level Objective Calculator
+ * 
+ * This library provides functions to calculate service level objectives
+ * for AEM Edge Delivery Services based on incident data.
+ * 
+ * Can be used both locally (aemstatus.net) and remotely (www.aem.live)
+ */
+
+/**
+ * Helper function to parse ISO 8601 timestamp format
+ * @param {string} timestamp - ISO 8601 timestamp
+ * @returns {Date|null} Parsed date or null if invalid
+ */
+export function parseIncidentTimestamp(timestamp) {
+  const date = new Date(timestamp);
+  if (!Number.isNaN(date.getTime())) {
+    return date;
+  }
+  return null;
+}
+
+/**
+ * Calculate uptime statistics for services based on incidents
+ * @param {Array} incidents - Array of incident objects
+ * @param {Object} options - Configuration options
+ * @param {number} options.windowDays - Number of days to look back (default: 90)
+ * @param {Object} options.services - Service SLA configuration
+ * @returns {Object} Service status object with uptime statistics
+ */
+export function calculateUptime(incidents, options = {}) {
+  const {
+    windowDays = 90,
+    services = {
+      delivery: 0.9999,
+      publishing: 0.999,
+    },
+  } = options;
+
+  const status = {};
+  Object.entries(services).forEach(([service, sla]) => {
+    status[service] = {
+      sla,
+      uptime: 1,
+      numIncidents: 0,
+      disruptionMins: 0,
+    };
+  });
+
+  const windowMins = windowDays * 24 * 60;
+  const windowMillis = windowMins * 60 * 1000;
+
+  incidents
+    .map((incident) => ({
+      startTime: parseIncidentTimestamp(incident.startTime),
+      endTime: parseIncidentTimestamp(incident.endTime),
+      impactedService: incident.impactedService,
+      errorRate: parseFloat(incident.errorRate) || 0,
+    }))
+    .filter(({
+      startTime, endTime, impactedService, errorRate,
+    }) => startTime && endTime && impactedService && errorRate)
+    .filter(({ startTime }) => startTime > new Date(Date.now() - windowMillis))
+    .forEach(({
+      startTime, endTime, impactedService, errorRate,
+    }) => {
+      const disruptionMins = Math.round((endTime.getTime() - startTime.getTime()) / 60000);
+      const downtimeMins = disruptionMins * errorRate;
+      const uptimeMins = windowMins - downtimeMins;
+      const uptime = uptimeMins / windowMins;
+
+      status[impactedService].uptime = uptime;
+      status[impactedService].numIncidents += 1;
+      status[impactedService].disruptionMins += disruptionMins;
+    });
+
+  Object.entries(status).forEach(([, serviceStatus]) => {
+    // format uptime percentage to 2 decimal places
+    // toFixed(2) rounds 99.99 up to 100.00, fall back to string slicing
+    // eslint-disable-next-line no-param-reassign
+    serviceStatus.uptimePercentage = `${(serviceStatus.uptime * 100)}`.slice(0, 6);
+  });
+
+  return status;
+}
+
+/**
+ * Determine the status class based on uptime vs SLA
+ * @param {number} uptime - Current uptime (0-1)
+ * @param {number} sla - SLA target (0-1)
+ * @returns {string} Status class: 'ok', 'warn', or 'err'
+ */
+export function getUptimeStatus(uptime, sla) {
+  if (uptime >= sla) {
+    return 'ok';
+  }
+  if (uptime >= sla - (1 - sla)) {
+    return 'warn';
+  }
+  return 'err';
+}


### PR DESCRIPTION
This PR extracts the SLO calculation logic into a reusable ES module library that can be used both locally on aemstatus.net and remotely on www.aem.live.

## Changes
- Created `scripts/slo-calculator.js` as a standalone ES module
- Exports three main functions:
  - `calculateUptime(incidents, options)` - Calculates uptime statistics
  - `parseIncidentTimestamp(timestamp)` - Parses ISO 8601 timestamps
  - `getUptimeStatus(uptime, sla)` - Determines status class (ok/warn/err)
- Updated `scripts/scripts.js` to import and use the library
- Configurable window days and service SLAs

## Benefits
- **Code reusability**: Can be loaded from www.aem.live via `https://www.aemstatus.net/scripts/slo-calculator.js`
- **No duplication**: Single source of truth for SLO calculations
- **Maintainability**: Changes only need to be made in one place
- **Testability**: Pure functions that can be easily unit tested

## Usage from www.aem.live
```javascript
import { calculateUptime } from 'https://www.aemstatus.net/scripts/slo-calculator.js';

const response = await fetch('https://www.aemstatus.net/incidents/index.json');
const incidents = await response.json();
const status = calculateUptime(incidents);
```

This will enable helix-website to use the same calculation logic without duplicating code.