### PR TITLE
fix: initialize totalDowntimeMins to prevent NaN uptime display

### DIFF
--- a/scripts/slo-calculator.js
+++ b/scripts/slo-calculator.js
@@ -44,6 +44,7 @@ export function calculateUptime(incidents, options = {}) {
       uptime: 1,
       numIncidents: 0,
       disruptionMins: 0,
+      totalDowntimeMins: 0,
     };
   });
 


### PR DESCRIPTION
## Summary
- Fixed NaN% being displayed for service uptime statistics
- Added missing initialization of `totalDowntimeMins: 0` in the status object

## Details
The `calculateUptime` function in `scripts/slo-calculator.js` was attempting to accumulate downtime using `totalDowntimeMins += downtimeMins` without initializing the field. This caused `undefined + number = NaN`, which propagated through to the uptime percentage display.

## Test plan
- [x] Verified uptime percentages now display correctly (e.g., "99.95%" instead of "NaN%")
- [x] Tested with live dev server and confirmed the fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)