### PR TITLE
chore: add post-mortem for Chrome 145 / 425 Too Early incident

### DIFF
--- a/incidents/html/AEM-chrome145-425.html
+++ b/incidents/html/AEM-chrome145-425.html
@@ -1,0 +1,145 @@
+<h1 class="none">Chrome 145 intermittently displays "425 Too Early" errors</h1>
+<article data-incident-start-time="2026-02-11T00:00:00Z" data-incident-end-time="2026-02-25T19:30:00Z"
+  data-incident-error-rate="" data-incident-impacted-service="publishing">
+
+  <p>
+    Starting February 11, 2026, users on Google Chrome version 145 began experiencing intermittent
+    "425 Too Early" errors when accessing AEM Edge Delivery Services pages on *.aem.live and
+    *.aem.page domains. The error appeared as a blank page with "Too Early" text, requiring users
+    to reload to access content. This particularly affected authoring workflows, including Sidekick
+    functionality and content preview.
+  </p>
+  <p>
+    The incident was caused by a regression in Chrome 145 that prevented the browser from properly
+    retrying requests after receiving HTTP 425 responses from Fastly's CDN during TLS 1.3 0-RTT
+    (early data) connections over HTTP/3. AEM infrastructure was not impacted; the issue was
+    entirely within the Chrome browser's handling of a standard CDN security response.
+  </p>
+
+  <h3>Root Cause</h3>
+  <p>
+    Chrome 145 introduced a change (<a href="https://chromium-review.googlesource.com/c/chromium/src/+/7157040">CL 7157040</a>)
+    that tightened the retry condition for HTTP 425 "Too Early" responses. The change checked a
+    cached SSLInfo value that was snapshotted before the QUIC handshake completed, causing
+    <code>early_data_accepted</code> to always read as <code>false</code>. This prevented Chrome
+    from retrying requests that Fastly correctly rejected with 425, as the CDN does not process
+    potentially replay-vulnerable 0-RTT early data requests.
+  </p>
+  <p>
+    The HTTP 425 status code is a standard mechanism for servers to indicate that a request sent as
+    TLS early data should be retried after the handshake completes. Previous Chrome versions and
+    other browsers (Safari, Firefox) handle this correctly by automatically retrying.
+  </p>
+  <p>
+    <a href="https://issues.chromium.org/issues/484218878">Chromium Issue 484218878</a><br>
+    <a href="https://www.fastlystatus.com/incident/378300">Fastly Incident 378300</a>
+  </p>
+
+  <h3>Detection</h3>
+  <p>
+    The incident was first reported internally on February 12, 2026 when team members encountered
+    425 errors while browsing www.aem.live. Additional customer reports followed over subsequent
+    days. The issue was correlated with the Chrome 145 stable release rollout beginning February 11.
+    Fastly published their incident notice on February 13, 2026.
+  </p>
+
+  <h3>Impact</h3>
+  <p>
+    The incident affected Chrome 145 users directly accessing AEM Edge Delivery Services
+    publishing infrastructure:
+  </p>
+  <ul>
+    <li>Preview pages on *.aem.page domains</li>
+    <li>Live pages on *.aem.live domains</li>
+    <li>www.aem.live documentation and resources</li>
+    <li>Sidekick extension functionality (intermittent load failures)</li>
+  </ul>
+  <p>
+    Production delivery through customer CDNs was unaffected, as customer CDNs do not use HTTP/3
+    for origin requests to *.aem.live. The error rate is not available as these errors occurred
+    in Fastly's TLS stack before reaching our logging infrastructure.
+  </p>
+
+  <h3>Resolution</h3>
+  <p>
+    The Chrome team identified and fixed the bug on February 16-17, 2026
+    (<a href="https://chromium-review.googlesource.com/c/chromium/src/+/7581133">CL 7581133</a>).
+    The fix was cherry-picked to Chrome 145 and 146 branches on February 19-20. On February 25,
+    2026 at 19:30 UTC, Fastly temporarily disabled 0-RTT for shared IP customers as an interim
+    mitigation while the Chrome fix propagates through stable channel updates.
+  </p>
+  <p>
+    Users experiencing issues can work around the problem by:
+  </p>
+  <ul>
+    <li>Reloading the page (content typically appears after refresh)</li>
+    <li>Disabling QUIC in Chrome: navigate to <code>chrome://flags</code>, set "Experimental QUIC protocol" to Disabled, and restart Chrome</li>
+    <li>Updating to the latest Chrome version once the fix is released to stable</li>
+  </ul>
+
+  <h3>Action Items</h3>
+  <p>
+    This incident highlights the challenge of third-party browser regressions affecting CDN
+    protocol optimizations.
+  </p>
+  <ul>
+    <li>
+      Request error visibility from Fastly: Get 425 error rates added to logging or dashboards
+      so future similar issues are measurable
+    </li>
+    <li>
+      Document H3/0-RTT toggle runbook: Quick reference for disabling these features on Fastly
+      if needed in future browser regressions
+    </li>
+    <li>
+      Subscribe to Chromium networking component: Early awareness of changes to QUIC/TLS
+      handling that could affect our users
+    </li>
+  </ul>
+
+  <time>2026-02-26T12:00:00.000Z</time>
+</article>
+
+<ul class="updates">
+  <li>
+    <h2>Resolved</h2>
+    <p>
+      Fastly has temporarily disabled 0-RTT for shared IP customers, mitigating the issue for
+      most users. Chrome has released fixes that will be included in upcoming stable updates.
+      Users still experiencing issues should reload the page or disable QUIC in Chrome flags.
+    </p>
+    <time>2026-02-25T19:30:00.000Z</time>
+  </li>
+
+  <li>
+    <h2>Monitoring</h2>
+    <p>
+      The Chrome team has identified the root cause and deployed a fix to the main branch.
+      Cherry-picks to Chrome 145 and 146 branches are in progress. Fastly is coordinating with
+      Chrome on timeline and preparing server-side mitigations.
+    </p>
+    <time>2026-02-17T05:00:00.000Z</time>
+  </li>
+
+  <li>
+    <h2>Identified</h2>
+    <p>
+      The issue has been identified as a Chrome 145 regression in handling HTTP 425 "Too Early"
+      responses for HTTP/3 QUIC 0-RTT connections. Fastly's CDN correctly returns 425 for early
+      data requests, but Chrome 145 fails to retry these requests. Workaround: disable QUIC in
+      chrome://flags or reload affected pages.
+    </p>
+    <time>2026-02-13T23:15:00.000Z</time>
+  </li>
+
+  <li>
+    <h2>Investigating</h2>
+    <p>
+      We are receiving reports of intermittent "Too Early" errors displayed to users on Chrome
+      when accessing *.aem.live and *.aem.page domains. Initial investigation suggests this is
+      related to TLS 1.3 early data handling and HTTP/3. We are coordinating with Fastly and
+      monitoring the Chrome issue tracker.
+    </p>
+    <time>2026-02-12T14:17:00.000Z</time>
+  </li>
+</ul>

--- a/incidents/html/AEM-chrome145-425.html
+++ b/incidents/html/AEM-chrome145-425.html
@@ -60,7 +60,8 @@
     <li>Live pages on *.aem.live domains</li>
     <li>www.aem.live documentation and resources</li>
     <li>Sidekick extension functionality (intermittent load failures)</li>
-  </ul>
+        <li>admin.hlx.page when fetched via Sidekick, or during the sign in flow</li>
+    </ul>
   <p>
     The errors were intermittent—a page reload was sufficient to recover in most cases. Production
     delivery through customer CDNs was unaffected, as customer CDNs do not use HTTP/3 for origin

--- a/incidents/html/AEM-chrome145-425.html
+++ b/incidents/html/AEM-chrome145-425.html
@@ -1,11 +1,12 @@
 <h1 class="none">Chrome 145 intermittently displays "425 Too Early" errors</h1>
 <article data-incident-start-time="2026-02-11T00:00:00Z" data-incident-end-time="2026-02-25T19:30:00Z"
-  data-incident-error-rate="" data-incident-impacted-service="publishing">
+  data-incident-error-rate="0.0" data-incident-impacted-service="publishing">
 
+  <h3>Executive Summary</h3>
   <p>
-    Starting February 11, 2026, users on Google Chrome version 145 began experiencing intermittent
-    "425 Too Early" errors when accessing AEM Edge Delivery Services pages on *.aem.live and
-    *.aem.page domains. The error appeared as a blank page with "Too Early" text, requiring users
+    From February 11 to February 25, 2026 (14 days), users on Google Chrome version 145 experienced
+    intermittent "425 Too Early" errors when accessing AEM Edge Delivery Services pages on *.aem.live
+    and *.aem.page domains. The error appeared as a blank page with "Too Early" text, requiring users
     to reload to access content. This particularly affected authoring workflows, including Sidekick
     functionality and content preview.
   </p>
@@ -42,11 +43,17 @@
     days. The issue was correlated with the Chrome 145 stable release rollout beginning February 11.
     Fastly published their incident notice on February 13, 2026.
   </p>
+  <p>
+    Automated monitoring did not detect this incident. The 425 errors occurred in Fastly's TLS
+    stack before requests reached our logging infrastructure, and proactive detection would have
+    required testing with pre-release Chrome versions—impractical given the number of browsers
+    and versions in use.
+  </p>
 
   <h3>Impact</h3>
   <p>
-    The incident affected Chrome 145 users directly accessing AEM Edge Delivery Services
-    publishing infrastructure:
+    The incident lasted 14 days, from February 11 to February 25, 2026, affecting Chrome 145
+    users directly accessing AEM Edge Delivery Services publishing infrastructure:
   </p>
   <ul>
     <li>Preview pages on *.aem.page domains</li>
@@ -55,8 +62,9 @@
     <li>Sidekick extension functionality (intermittent load failures)</li>
   </ul>
   <p>
-    Production delivery through customer CDNs was unaffected, as customer CDNs do not use HTTP/3
-    for origin requests to *.aem.live. The error rate is not available as these errors occurred
+    The errors were intermittent—a page reload was sufficient to recover in most cases. Production
+    delivery through customer CDNs was unaffected, as customer CDNs do not use HTTP/3 for origin
+    requests to *.aem.live. Precise error rate metrics are unavailable as the 425 errors occurred
     in Fastly's TLS stack before reaching our logging infrastructure.
   </p>
 
@@ -78,10 +86,6 @@
   </ul>
 
   <h3>Action Items</h3>
-  <p>
-    This incident highlights the challenge of third-party browser regressions affecting CDN
-    protocol optimizations.
-  </p>
   <ul>
     <li>
       Request error visibility from Fastly: Get 425 error rates added to logging or dashboards
@@ -104,9 +108,9 @@
   <li>
     <h2>Resolved</h2>
     <p>
-      Fastly has temporarily disabled 0-RTT for shared IP customers, mitigating the issue for
-      most users. Chrome has released fixes that will be included in upcoming stable updates.
-      Users still experiencing issues should reload the page or disable QUIC in Chrome flags.
+      Fastly has disabled 0-RTT on shared IPs serving *.aem.page and *.aem.live, resolving the
+      issue. Chrome has separately released a fix (CL 7581133) that will ship in an upcoming
+      stable update, after which Fastly's configuration change can be reverted.
     </p>
     <time>2026-02-25T19:30:00.000Z</time>
   </li>

--- a/incidents/index.json
+++ b/incidents/index.json
@@ -26,7 +26,16 @@
     "incidentUpdated": "2026-02-26T12:00:00.000Z",
     "startTime": "2026-02-11T00:00:00Z",
     "endTime": "2026-02-25T19:30:00Z",
-    "impactedService": "publishing"
+    "impactedService": "publishing",
+    "affectedComponents": [
+      "delivery",
+      "publishing"
+    ],
+    "internalServices": [
+      "sidekick"
+    ],
+    "externalVendors": null,
+    "rootCause": "dependency-issue"
   },
   {
     "code": "AEM-65vahxsa",

--- a/incidents/index.json
+++ b/incidents/index.json
@@ -21,11 +21,12 @@
   {
     "code": "AEM-chrome145-425",
     "name": "Chrome 145 intermittently displays \"425 Too Early\" errors",
-    "message": "Starting February 11, 2026, users on Google Chrome version 145 began experiencing intermittent\n    \"425 Too Early\" errors when accessing AEM Edge Delivery Services pages on *.aem.live and\n    *.aem.page domains. The error appeared as a blank page with \"Too Early\" text, requiring users\n    to reload to access content. This particularly affected authoring workflows, including Sidekick\n    functionality and content preview.",
+    "message": "From February 11 to February 25, 2026 (14 days), users on Google Chrome version 145 experienced\n    intermittent \"425 Too Early\" errors when accessing AEM Edge Delivery Services pages on *.aem.live\n    and *.aem.page domains. The error appeared as a blank page with \"Too Early\" text, requiring users\n    to reload to access content. This particularly affected authoring workflows, including Sidekick\n    functionality and content preview.",
     "impact": "none",
     "incidentUpdated": "2026-02-26T12:00:00.000Z",
     "startTime": "2026-02-11T00:00:00Z",
     "endTime": "2026-02-25T19:30:00Z",
+    "errorRate": "0.0",
     "impactedService": "publishing",
     "affectedComponents": [
       "delivery",

--- a/incidents/index.json
+++ b/incidents/index.json
@@ -19,6 +19,16 @@
     "rootCause": "dependency-issue"
   },
   {
+    "code": "AEM-chrome145-425",
+    "name": "Chrome 145 intermittently displays \"425 Too Early\" errors",
+    "message": "Starting February 11, 2026, users on Google Chrome version 145 began experiencing intermittent\n    \"425 Too Early\" errors when accessing AEM Edge Delivery Services pages on *.aem.live and\n    *.aem.page domains. The error appeared as a blank page with \"Too Early\" text, requiring users\n    to reload to access content. This particularly affected authoring workflows, including Sidekick\n    functionality and content preview.",
+    "impact": "none",
+    "incidentUpdated": "2026-02-26T12:00:00.000Z",
+    "startTime": "2026-02-11T00:00:00Z",
+    "endTime": "2026-02-25T19:30:00Z",
+    "impactedService": "publishing"
+  },
+  {
     "code": "AEM-65vahxsa",
     "name": "Delivery service disrupted by Cloudflare R2 outage",
     "message": "On February 7, 2026 between 01:57 UTC and 02:34 UTC, delivery service requests experienced elevated error\n        rates of approximately 0.035% due to an outage in Cloudflare's R2 storage service. Our automated monitoring\n        detected the issue at 02:05 UTC (8 minutes after onset), and we initiated a manual failover to an alternate\n        cloud provider, restoring the service at 02:34 UTC (37 minutes after onset).",

--- a/incidents/index.json
+++ b/incidents/index.json
@@ -110,7 +110,9 @@
     "affectedComponents": [
       "publishing"
     ],
-    "internalServices": null,
+    "internalServices": [
+      "admin-api"
+    ],
     "externalVendors": null,
     "rootCause": "deployment-issue"
   },
@@ -203,7 +205,9 @@
     "endTime": "2025-10-09T17:43:54.488Z",
     "errorRate": "0.000",
     "impactedService": "publishing",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "publishing"
+    ],
     "internalServices": [
       "code-sync"
     ],
@@ -275,7 +279,9 @@
     "internalServices": [
       "admin-api"
     ],
-    "externalVendors": null,
+    "externalVendors": [
+      "webpack"
+    ],
     "rootCause": "deployment-issue",
     "startTime": "2025-04-08T10:44:51.000Z",
     "endTime": "2025-04-08T11:23:17.000Z"
@@ -304,7 +310,9 @@
     "message": "Executive Summary\n\nOn March 15, 2025, between 7:00 AM and 11:21 AM UTC, approximately 90% of customers experienced issues with the delivery of RUM (Real User Monitoring) scripts due to availability problems with the unpkg.com backend. The incident was caused by unpkg.com experiencing degraded performance, combined with our system's inability to properly handle first-byte timeout errors in the backend fallback mechanism. The issue was identified and resolved by adjusting timeout configurations an",
     "impact": "none",
     "incidentUpdated": "2025-03-18T12:07:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "delivery"
+    ],
     "internalServices": [
       "rum"
     ],
@@ -404,7 +412,9 @@
     "message": "An aemsites organisation owner updated the AEM Code Sync config and accidentally removed all repositories from the config. Github UI is not fully intuitive.\n\nAs a follow up step, a reminder email has been sent to all the owners.",
     "impact": "minor",
     "incidentUpdated": "2024-12-13T09:05:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "publishing"
+    ],
     "internalServices": [
       "code-sync"
     ],
@@ -439,7 +449,9 @@
     "message": "On 11.09.2024 12:30 UTC we noticed that the AEM Code Sync Github application has stopped dispatching github events since 05:00 UTC. As a result, github actions that are triggered on a repository_dispatch event were not longer invoked. \n\nThe reason was a removed content-write permission of the AEM Code Sync Github application which is required to dispatch events. After restoring the permission, the notifications were dispatched again. \n\nCustomers that use repository_dispatch events in their githu",
     "impact": "minor",
     "incidentUpdated": "2024-09-11T14:08:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "publishing"
+    ],
     "internalServices": [
       "code-sync"
     ],
@@ -476,7 +488,9 @@
     "affectedComponents": [
       "publishing"
     ],
-    "internalServices": null,
+    "internalServices": [
+      "admin-api"
+    ],
     "externalVendors": null,
     "rootCause": "deployment-issue",
     "startTime": "2024-07-17T16:02:00.000Z",
@@ -584,7 +598,9 @@
     "message": "Between 7:00 am and 12:45 pm (UTC) today, the JavaScript delivery feature of the Helix RUM Collector Service experienced an outage that resulted in slow responses and responses with status code 520 for following request types:\n\n\nhelix-rum-js: this slowed down page rendering for customers of Adobe Experience Manager as a Cloud Service that are part of the VIP program for RUM collection in AEM CS. This affected a small double digit number of customers.\nhelix-rum-enhancer: all customers of AEM CS a",
     "impact": "minor",
     "incidentUpdated": "2024-04-12T14:31:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "delivery"
+    ],
     "internalServices": [
       "rum"
     ],
@@ -601,7 +617,9 @@
     "message": "On March 18 the system experienced a unexpected indexing load that overwhelmed the indexing queue. Due to a suboptimal configuration the system was not able to process the queue fast enough and clogged indexing processing for all customers.\n\nConsequently, index updates might have been delayed by over 1 hour.\n\nAfter identifying the problem we could reconfigure the queue to avoid similar problems in the future.",
     "impact": "minor",
     "incidentUpdated": "2024-05-27T14:58:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "delivery"
+    ],
     "internalServices": [
       "indexing"
     ],
@@ -619,7 +637,9 @@
     "affectedComponents": [
       "publishing"
     ],
-    "internalServices": null,
+    "internalServices": [
+      "admin-api"
+    ],
     "externalVendors": null,
     "rootCause": "resource-limits",
     "startTime": "2024-03-04T01:07:00.000Z",
@@ -680,7 +700,9 @@
     "message": "We discovered that the errors were caused by an issue with a specific IO region in Fastly. The impact of the incident lasted for approximately 22 minutes, from 11:42 to 12:04 UTC. During that period we saw an increase of the media delivery error rate from 0% to 4.8%. About 50% of the errored requests were initiated by Bots. Customer impact has been negligible. We will continue to closely monitor error rates of the the infrastructure we are using and take action if necessary.",
     "impact": "minor",
     "incidentUpdated": "2023-12-15T15:11:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "delivery"
+    ],
     "internalServices": [
       "media"
     ],
@@ -744,7 +766,9 @@
     "message": "Between 9:18 UTC and 14:36 UTC on 18-oct-2023 due to a change in the domain of our externally facing documentation website https://www.hlx.live to https://www.aem.live a small portion of www.hlx.com/tools which hosts resources used by sidekick was redirected accidentally.   \n\nOur analysis shows that 0.6% of the traffic to www.hlx.com/tools during that time window was wrongly redirected and was potentially leading to an issue where users were not able to open up the sidekick library under certain",
     "impact": "minor",
     "incidentUpdated": "2023-10-19T14:01:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "publishing"
+    ],
     "internalServices": [
       "sidekick"
     ],
@@ -762,7 +786,9 @@
     "affectedComponents": [
       "delivery"
     ],
-    "internalServices": null,
+    "internalServices": [
+      "dns"
+    ],
     "externalVendors": null,
     "rootCause": "dns-issue",
     "startTime": "2023-09-28T15:36:00.000Z",
@@ -777,7 +803,9 @@
     "affectedComponents": [
       "delivery"
     ],
-    "internalServices": null,
+    "internalServices": [
+      "dns"
+    ],
     "externalVendors": null,
     "rootCause": "dns-issue",
     "startTime": "2023-09-26T00:00:00.000Z",
@@ -808,7 +836,9 @@
     "affectedComponents": [
       "publishing"
     ],
-    "internalServices": null,
+    "internalServices": [
+      "admin-api"
+    ],
     "externalVendors": null,
     "rootCause": "third-party-outage",
     "startTime": "2023-06-07T18:56:00.000Z",
@@ -839,7 +869,9 @@
     "message": "Between 10:01 am an 10:16 am today, a configuration change to a Serverless function caused the GitHub bot to fail to respond to notifications from GitHub. In total 31 requests were affected.\n\nIf you pushed code changes in that time period, they might not have come through. You can remedy this by pushing an additional, empty commit to the same branch.\n\nIn order to prevent similar issues to arise in the future, we will establish a review process for configuration changes to the production services",
     "impact": "minor",
     "incidentUpdated": "2023-02-09T10:28:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "publishing"
+    ],
     "internalServices": [
       "code-sync"
     ],
@@ -907,7 +939,9 @@
     "message": "An new version of the Franklin admin service conflicted with a behavior of the Franklin github bot which lead to a delay of synchronizations of code updates. The issue was not noticed for a few hours as the function that was affected was not heavily used at the time.\nThe issue is fixed in a newly released version of the Franklin github bot, and all affected code synchronization will be synchronized.",
     "impact": "minor",
     "incidentUpdated": "2022-12-22T22:54:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "publishing"
+    ],
     "internalServices": [
       "code-sync"
     ],
@@ -927,7 +961,9 @@
     "affectedComponents": [
       "publishing"
     ],
-    "internalServices": null,
+    "internalServices": [
+      "sidekick"
+    ],
     "externalVendors": [
       "microsoft"
     ],
@@ -957,7 +993,9 @@
     "message": "The underlying reason for the increased error rates on media delivery was a partial outage of Fastly’s Image Optimizer:\nhttps://status.fastly.com/incidents/s542qjby04vb\n\nWe have opened an issue with Fastly support, asking for an official statement about how Fastly is going to address this issue and prevent future such outages.",
     "impact": "minor",
     "incidentUpdated": "2022-06-29T15:29:00.000Z",
-    "affectedComponents": null,
+    "affectedComponents": [
+      "delivery"
+    ],
     "internalServices": [
       "media"
     ],
@@ -1026,7 +1064,9 @@
     "affectedComponents": [
       "publishing"
     ],
-    "internalServices": null,
+    "internalServices": [
+      "admin-api"
+    ],
     "externalVendors": [
       "microsoft"
     ],


### PR DESCRIPTION
## Summary

Documents the Feb 11-25, 2026 incident where Chrome 145 users experienced intermittent 425 Too Early errors on \*.aem.page and \*.aem.live domains.

## Root Cause

Chrome 145 introduced a regression that prevented proper retry of HTTP 425 responses during TLS 1.3 0-RTT connections over HTTP/3. Fastly correctly returned 425 for early data requests, but Chrome failed to retry.

## Impact

- Affected: Preview/publish on \*.aem.page and \*.aem.live domains
- Unaffected: Customer CDN delivery (no HTTP/3 origin requests)
- Sidekick intermittent load failures

## Resolution

- Chrome fix deployed (CL 7581133)
- Fastly disabled 0-RTT on Feb 25, 19:30 UTC as interim mitigation

## References

- [Chromium Issue 484218878](https://issues.chromium.org/issues/484218878)
- [Fastly Incident 378300](https://www.fastlystatus.com/incident/378300)