### PR TITLE
Postmortem: Cloudflare IAD connectivity incident (2026-04-23)

### DIFF
--- a/incidents/html/AEM-cfiad-0423.html
+++ b/incidents/html/AEM-cfiad-0423.html
@@ -1,0 +1,74 @@
+<h1 class="minor">Elevated 5xx errors on delivery due to Cloudflare IAD connectivity issues</h1>
+<article data-incident-start-time="2026-04-23T03:24:00.000Z" data-incident-end-time="2026-04-23T04:03:00.000Z"
+    data-incident-error-rate="0.00123" data-incident-impacted-service="delivery">
+
+    <h3>Executive Summary</h3>
+    <p>
+        On April 23, 2026 between 03:24 and 04:03 UTC, AEM delivery experienced elevated 5xx errors
+        driven by a Cloudflare network connectivity incident in the Ashburn, Virginia (IAD) region.
+        A total of 3.46K requests returned 5xx status codes, dominated by HTTP 503 responses and
+        <code>first byte timeout</code> errors in the HTML pipeline path. The overall delivery error
+        rate during the window was 0.123%.
+    </p>
+
+    <h3>Root Cause</h3>
+    <p>
+        The incident was caused by an upstream network connectivity issue in Cloudflare's Ashburn,
+        Virginia (IAD) data center, tracked as
+        <a href="https://www.cloudflarestatus.com/incidents/qzb6ncj7v2qc">Cloudflare incident qzb6ncj7v2qc</a>.
+        AEM delivery runs on a dual-stack architecture, with roughly 50% of traffic served from
+        Cloudflare backends. Because IAD is configured as the Fastly shield, all Fastly requests to
+        the Cloudflare-backed stack transit through IAD regardless of the PoP that initially
+        received them, so the full population of Cloudflare-stack requests was exposed to the IAD
+        connectivity issue.
+    </p>
+
+    <h3>Resolution</h3>
+    <p>
+        No action was required on the AEM side. Cloudflare deployed a fix at 04:03 UTC and marked
+        the incident resolved at 04:36 UTC, at which point error rates returned to baseline. Customers
+        whose content delivery requests failed during the window would have received transient 503
+        responses; most client and CDN retry behavior would have absorbed these, and no data loss
+        or persistent degradation occurred.
+    </p>
+
+    <h3>Action Items</h3>
+    <ul>
+        <li>Continue closely monitoring error rates and traffic; if a similar upstream incident recurs,
+            temporarily fail-over to the non-affected stack.</li>
+    </ul>
+
+    <time>2026-04-23T05:00:00.000Z</time>
+</article>
+
+<ul class="updates">
+    <li>
+        <h2>Resolved</h2>
+        <p>Cloudflare has resolved the underlying IAD connectivity incident and AEM delivery error
+            rates have returned to baseline. No further action is required.</p>
+        <time>2026-04-23T04:36:00.000Z</time>
+    </li>
+
+    <li>
+        <h2>Monitoring</h2>
+        <p>Cloudflare has deployed a fix for the IAD connectivity issue. We are monitoring delivery
+            error rates as they return to normal.</p>
+        <time>2026-04-23T04:03:00.000Z</time>
+    </li>
+
+    <li>
+        <h2>Identified</h2>
+        <p>Elevated 5xx errors on AEM delivery have been correlated with a Cloudflare network
+            connectivity incident in the Ashburn, Virginia (IAD) region
+            (<a href="https://www.cloudflarestatus.com/incidents/qzb6ncj7v2qc">cloudflarestatus.com</a>).
+            Impact is limited to a small fraction of delivery requests.</p>
+        <time>2026-04-23T03:57:00.000Z</time>
+    </li>
+
+    <li>
+        <h2>Investigating</h2>
+        <p>We are observing a spike in 5xx errors on AEM delivery, primarily affecting HTML pipeline
+            requests with first byte timeouts. Our team is investigating.</p>
+        <time>2026-04-23T03:30:00.000Z</time>
+    </li>
+</ul>

--- a/incidents/index.json
+++ b/incidents/index.json
@@ -1,5 +1,16 @@
 [
   {
+    "code": "AEM-cfiad-0423",
+    "name": "Elevated 5xx errors on delivery due to Cloudflare IAD connectivity issues",
+    "message": "On April 23, 2026 between 03:24 and 04:03 UTC, AEM delivery experienced elevated 5xx errors\n        driven by a Cloudflare network connectivity incident in the Ashburn, Virginia (IAD) region.\n        A total of 3.46K requests returned 5xx status codes, dominated by HTTP 503 responses and\n        first byte timeout errors in the HTML pipeline path. The overall delivery error\n        rate during the window was 0.123%.",
+    "impact": "minor",
+    "incidentUpdated": "2026-04-23T05:00:00.000Z",
+    "startTime": "2026-04-23T03:24:00.000Z",
+    "endTime": "2026-04-23T04:03:00.000Z",
+    "errorRate": "0.00123",
+    "impactedService": "delivery"
+  },
+  {
     "code": "091tp5sj",
     "name": "Pipeline timeout errors affecting Page Delivery",
     "message": "On Wednesday, April 8, 2026 between 15:01 UTC and 15:12 UTC, we observed a brief spike in 503 errors affecting AEM\n    Delivery across multiple hosts. The incident was detected via automated error-rate monitoring. The errors were associated with the HTML pipeline and resulted in a small number of\n    failed requests. The overall error rate remained well below 0.01% (~0.0068%), and impact to end users was minimal.",

--- a/incidents/index.json
+++ b/incidents/index.json
@@ -8,7 +8,15 @@
     "startTime": "2026-04-23T03:24:00.000Z",
     "endTime": "2026-04-23T04:03:00.000Z",
     "errorRate": "0.00123",
-    "impactedService": "delivery"
+    "impactedService": "delivery",
+    "affectedComponents": [
+      "delivery"
+    ],
+    "internalServices": null,
+    "externalVendors": [
+      "cloudflare"
+    ],
+    "rootCause": "third-party-outage"
   },
   {
     "code": "091tp5sj",


### PR DESCRIPTION
## Summary
- Adds a postmortem for the 2026-04-23 03:24–04:03 UTC delivery 5xx spike caused by the upstream Cloudflare IAD connectivity incident ([qzb6ncj7v2qc](https://www.cloudflarestatus.com/incidents/qzb6ncj7v2qc)).
- 3.46K 5xx responses over the window; overall delivery error rate 0.123%. Impact concentrated on Fastly → Cloudflare-stack traffic (IAD is the Fastly shield, so all Fastly requests to the Cloudflare-backed stack were exposed).
- No AEM-side action was required; Cloudflare deployed a fix at 04:03 UTC and resolved at 04:36 UTC.

## Test plan
- [x] Postmortem renders correctly on the status page
- [x] `incidents/index.json` updated (follow-up if needed)

Test url: https://incident-cfiad-0423--aem-status--adobe.aem.live/details.html?incident=AEM-cfiad-0423

🤖 Generated with [Claude Code](https://claude.com/claude-code)