### PR TITLE
fix: handle race condition in workflow push step

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -54,7 +54,12 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add incidents/index.json
           git commit -m "chore: update incidents index [skip ci]"
-          git push origin main
+          # Pull with rebase to handle concurrent pushes, then push with retry
+          for i in 1 2 3; do
+            git pull --rebase origin main && git push origin main && break
+            echo "Push attempt $i failed, retrying..."
+            sleep 2
+          done
       
       - name: Build And Deploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -55,11 +55,20 @@ jobs:
           git add incidents/index.json
           git commit -m "chore: update incidents index [skip ci]"
           # Pull with rebase to handle concurrent pushes, then push with retry
+          push_succeeded=false
           for i in 1 2 3; do
-            git pull --rebase origin main && git push origin main && break
-            echo "Push attempt $i failed, retrying..."
+            if git pull --rebase origin main && git push origin main; then
+              push_succeeded=true
+              break
+            fi
+            echo "Push attempt $i failed, aborting any in-progress rebase and retrying..."
+            git rebase --abort 2>/dev/null || true
             sleep 2
           done
+          if [ "$push_succeeded" = false ]; then
+            echo "Failed to push after 3 attempts"
+            exit 1
+          fi
       
       - name: Build And Deploy
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
## Problem
The Azure Static Web Apps CI/CD workflow failed because `git push` was rejected when another workflow run pushed to main concurrently:

```
! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/adobe/aem-status'
```

## Solution
Add `git pull --rebase` before pushing, with a retry loop (up to 3 attempts) to handle race conditions when multiple workflow runs try to push the incidents index update simultaneously.

## Testing
This is a workflow change that will be tested on the next push to main after merging.