### PR TITLE
feat: add postmortem for increased error rate due to Cloudflare origin latency

### DIFF
--- a/incidents/index.json
+++ b/incidents/index.json
@@ -1,5 +1,16 @@
 [
   {
+    "code": "AEM-em94pbqm",
+    "name": "Increased error rate due to increased origin latency",
+    "message": "On May 11, 2026, starting at 05:29 UTC, elevated origin latency was observed on Cloudflare Workers serving AEM delivery traffic. The increased latency caused `first byte timeout` errors between 05:56 and 06:32 UTC, resulting in an error rate of 0.029%. The issue was detected via monitoring alert. No customers reported impact. Both error rate and origin latency recovered on their own — error rate by 06:32 UTC and origin latency fully by 07:10 UTC.",
+    "impact": "none",
+    "incidentUpdated": "2026-05-11T10:22:17.000Z",
+    "startTime": "2026-05-11T05:56:00Z",
+    "endTime": "2026-05-11T06:32:00Z",
+    "errorRate": "0.00029",
+    "impactedService": "delivery"
+  },
+  {
     "code": "AEM-t58nxd8r",
     "name": "Intermittent network errors affecting publishing globally",
     "message": "On May 7, 2026 at 23:45 UTC, customers globally began experiencing intermittent error messages while authoring and publishing content, both of which rely on the publishing back-end. The issue persisted for approximately 6 hours, resolving at 05:30 UTC on May 8, 2026. Approximately 0.34% of requests were affected during the incident window, impacting around a dozen customers across multiple regions including the United States, Australia, India, Japan, Ireland, the United Kingdom, and Singapore, a",

--- a/incidents/index.json
+++ b/incidents/index.json
@@ -1,7 +1,7 @@
 [
   {
     "code": "AEM-em94pbqm",
-    "name": "Increased error rate due to increased origin latency",
+    "name": "Increased error rate due to Cloudflare origin latency",
     "message": "On May 11, 2026, starting at 05:29 UTC, elevated origin latency was observed on Cloudflare Workers serving AEM delivery traffic. The increased latency caused `first byte timeout` errors between 05:56 and 06:32 UTC, resulting in an error rate of 0.029%. The issue was detected via monitoring alert. No customers reported impact. Both error rate and origin latency recovered on their own — error rate by 06:32 UTC and origin latency fully by 07:10 UTC.",
     "impact": "none",
     "incidentUpdated": "2026-05-11T10:22:17.000Z",

--- a/incidents/index.json
+++ b/incidents/index.json
@@ -8,7 +8,15 @@
     "startTime": "2026-05-11T05:56:00Z",
     "endTime": "2026-05-11T06:32:00Z",
     "errorRate": "0.00029",
-    "impactedService": "delivery"
+    "impactedService": "delivery",
+    "affectedComponents": [
+      "delivery"
+    ],
+    "internalServices": null,
+    "externalVendors": [
+      "cloudflare"
+    ],
+    "rootCause": "network-issue"
   },
   {
     "code": "AEM-t58nxd8r",

--- a/incidents/md/AEM-em94pbqm.markdown
+++ b/incidents/md/AEM-em94pbqm.markdown
@@ -41,4 +41,4 @@ Monitoring alert fired. Team observed elevated `first byte timeout` errors and t
 ### Identified
 2026-05-11T05:29:00Z
 
-Elevated origin latency detected on Cloudflare Workers. No corresponding incident on the Cloudflare status page.
+Elevated origin latency detected on Cloudflare Workers via [monitoring alert / dashboard observation]. No corresponding incident on the Cloudflare status page.

--- a/incidents/md/AEM-em94pbqm.markdown
+++ b/incidents/md/AEM-em94pbqm.markdown
@@ -16,7 +16,7 @@ On May 11, 2026, starting at 05:29 UTC, elevated origin latency was observed on 
 
 ### Root Cause
 
-Cloudflare Workers experienced elevated origin latency for approximately 100 minutes (05:29–07:10 UTC). No incident was posted on the Cloudflare status page and the root cause remains unknown. The latency spike caused `first byte timeout` errors on the AEM delivery stack for 36 minutes until traffic normalized.
+Origin requests to Cloudflare Workers experienced elevated latency for approximately 100 minutes (05:29–07:10 UTC). No incident was posted on the Cloudflare status page and the root cause remains unknown. The latency spike caused `first byte timeout` errors on the AEM delivery stack for 36 minutes until traffic normalized.
 
 ### Resolution
 

--- a/incidents/md/AEM-em94pbqm.markdown
+++ b/incidents/md/AEM-em94pbqm.markdown
@@ -1,0 +1,44 @@
+---
+kind: postmortem
+impact: none
+start-time: 2026-05-11T05:56:00Z
+end-time: 2026-05-11T06:32:00Z
+error-rate: 0.00029
+impacted-service: delivery
+postmortem-completed: 2026-05-11T10:22:17Z
+---
+
+# Increased error rate due to increased origin latency
+
+### Executive Summary
+
+On May 11, 2026, starting at 05:29 UTC, elevated origin latency was observed on Cloudflare Workers serving AEM delivery traffic. The increased latency caused `first byte timeout` errors between 05:56 and 06:32 UTC, resulting in an error rate of 0.029%. The issue was detected via monitoring alert. No customers reported impact. Both error rate and origin latency recovered on their own — error rate by 06:32 UTC and origin latency fully by 07:10 UTC.
+
+### Root Cause
+
+Cloudflare Workers experienced elevated origin latency for approximately 100 minutes (05:29–07:10 UTC). No incident was posted on the Cloudflare status page and the root cause remains unknown. The latency spike caused `first byte timeout` errors on the AEM delivery stack for 36 minutes until traffic normalized.
+
+### Resolution
+
+The origin latency and resulting error rate recovered without intervention. The team was prepared to switch origins from Cloudflare to AWS if conditions worsened, but that action was not necessary. No customer action is required.
+
+### Action Items
+
+- None. Monitoring alerted as expected and the team was prepared to act.
+
+## Updates
+
+### Resolved
+2026-05-11T06:32:00Z
+
+Error rate returned to normal. Origin latency on Cloudflare Workers continued recovering and fully normalized by 07:10 UTC.
+
+### Monitoring
+2026-05-11T05:56:00Z
+
+Monitoring alert fired. Team observed elevated `first byte timeout` errors and tracked origin latency. A switch from Cloudflare to AWS origins was prepared as a mitigation option.
+
+### Identified
+2026-05-11T05:29:00Z
+
+Elevated origin latency detected on Cloudflare Workers. No corresponding incident on the Cloudflare status page.

--- a/incidents/md/AEM-em94pbqm.markdown
+++ b/incidents/md/AEM-em94pbqm.markdown
@@ -8,7 +8,7 @@ impacted-service: delivery
 postmortem-completed: 2026-05-11T10:22:17Z
 ---
 
-# Increased error rate due to increased origin latency
+# Increased error rate due to Cloudflare origin latency
 
 ### Executive Summary
 


### PR DESCRIPTION
Postmortem for #em94pbqm

URL: https://aem-em94pbqm--aem-status--adobe.aem.page/details.html?incident=AEM-em94pbqm