### PR TITLE
fix: align OK-state error rate label with 0.5% threshold

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -698,7 +698,7 @@ footer a:any-link:hover {
 }
 
 #current-incident.ok .section-head h2::after {
-  content: ' (No Significant Impact, Error rate < 0.1%)';
+  content: ' (No Significant Impact, Error rate < 0.5%)';
 }
 
 #current-incident .status-update {


### PR DESCRIPTION
Aligns the UI "No Significant Impact" label with the documented `none` impact threshold (< 0.5%), correcting the previous 0.1% value.

https://fix-error-rate-threshold--aem-status--adobe.aem.page/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)